### PR TITLE
fix: enable CORS for Fetch API

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ npm run start:dev
 ```
 
 正常运行之后可以试用一下地址
-API 请求地址： `localhost:3000`
-API 文档：`localhost:3000/api`
+API 请求地址： `localhost:3001`
+API 文档：`localhost:3001/api`
 
 ---

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,12 @@ async function bootstrap() {
     .build();
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('api', app, document);
-
-  await app.listen(3000);
+  app.enableCors({
+    origin: "*",
+    methods: "GET,HEAD,PUT,PATCH,POST,DELETE",
+    allowedHeaders: "Content-Type, Accept",
+  });
+  
+  await app.listen(3001);
 }
 bootstrap();


### PR DESCRIPTION
This PR enables CORS for Fetch API. We would have some restraints on Content-Type without this.

The port number is also modified to avoid conflict with frontend.